### PR TITLE
removed unneeded pylint

### DIFF
--- a/.github/workflows/pr_request_checks.yml
+++ b/.github/workflows/pr_request_checks.yml
@@ -24,4 +24,3 @@ jobs:
       - name: Run tests and checks
         run: |
           pytest tests/
-          pylint swarms_torch


### PR DESCRIPTION
The pr_requests_checks github workflow ran pylint on swarms_torch, which is no longer a thing.

The correct workflow would be to run pylint on the code in the <projectname> directory.